### PR TITLE
Credential image formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 node_modules
 reports
 .cache
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # bedrock-vue-vc ChangeLog
 
-## 2.0.3 - 2022-11-dd
+## 2.0.3 - 2023-11-dd
 
 ### Fixed
 - Allows non-square vc images to not distort.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-vc ChangeLog
 
+## 2.0.3 - 2022-11-dd
+
+### Fixed
+- Allows non-square vc images to not distort.
+
 ## 2.0.2 - 2022-08-22
 
 ### Fixed

--- a/components/CredentialBase.vue
+++ b/components/CredentialBase.vue
@@ -14,6 +14,7 @@
       </slot>
       <slot name="image">
         <dynamic-image
+          class="q-ma-xs"
           :src="imageOverride.length > 0 ? imageOverride : credentialImage"
           :size="dense ? 'sm' : 'md'" />
       </slot>

--- a/components/CredentialDetail.vue
+++ b/components/CredentialDetail.vue
@@ -6,6 +6,7 @@
         title="Issued by"
         :value="issuerName" />
       <dynamic-image
+        class="q-mx-md"
         :src="credentialImage"
         size="lg" />
       <credential-field

--- a/components/DynamicImage.vue
+++ b/components/DynamicImage.vue
@@ -74,6 +74,10 @@ $md: 75px;
 $lg: 125px;
 $xl: 150px;
 
+img {
+    object-fit: contain
+  }
+
 .credential-card-image-xs {
   svg {
     width: $xs;
@@ -153,5 +157,6 @@ $xl: 150px;
     height: $xl;
     border-radius: 4px;
   }
+
 }
 </style>


### PR DESCRIPTION
#### _Resolves - Allows non-square credential images to not distort_

---

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

- Bug fix.

<br/>

### What is the current behavior? (You can also link to an open issue here)

- A credential image will stretch to the shape of a square regardless of its dimensions.

<br/>

### What is the new behavior?

- The container of the image remains a square, but allows the image itself to fit inside with its natural dimensions (height & width) with an addition of minor margins.

<br/>

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

- [ ] Yes
- [X] No

<br/>

### How has this been tested?

- Tested locally in veres-wallet with a symlink to bedrock-vue-vc.

<br/>

### Screenshots:

> Before
> <img src="https://github.com/digitalbazaar/bedrock-vue-vc/assets/56396286/d1b674f2-d643-480f-acf8-ea77f92df789" alt="before" width="500" />

> After
> <img src="https://github.com/digitalbazaar/bedrock-vue-vc/assets/56396286/f8653a20-6376-4765-8dd8-bd66e5bf0e08" alt="after" width="500" />