### PR TITLE
Add default text for missing credential description.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-vc ChangeLog
 
+## 2.0.4 - 2023-11-dd
+
+### Added
+- Include default text when credential description is blank.
+
 ## 2.0.3 - 2023-11-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # bedrock-vue-vc ChangeLog
 
-## 2.0.4 - 2023-11-dd
+## 2.1.0 - 2023-12-dd
 
 ### Added
 - Include default text when credential description is blank.

--- a/components/CredentialDetail.vue
+++ b/components/CredentialDetail.vue
@@ -10,8 +10,8 @@
         :src="credentialImage"
         size="lg" />
       <credential-field
-        :title="name"
         :value="description"
+        :title="credentialName"
         class="col text-center"
         title-class="text-subtitle1"
         value-class="text-body2 text-grey-7" />
@@ -44,11 +44,6 @@ const {
   issuerName, credentialDescription
 } = useCredentialCommon({
   credential: toRef(props, 'credential')
-});
-
-const name = computed(() => {
-  const name = unref(credentialName);
-  return name || 'No credential name available.';
 });
 
 const description = computed(() => {

--- a/components/CredentialDetail.vue
+++ b/components/CredentialDetail.vue
@@ -10,10 +10,10 @@
         :src="credentialImage"
         size="lg" />
       <credential-field
+        :title="name"
+        :value="description"
         class="col text-center"
-        :title="credentialName"
         title-class="text-subtitle1"
-        :value="credentialDescription"
         value-class="text-body2 text-grey-7" />
     </div>
   </div>
@@ -23,7 +23,7 @@
 /*!
  * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import {defineProps, toRef} from 'vue';
+import {computed, defineProps, toRef, unref} from 'vue';
 import CredentialField from './CredentialField.vue';
 import DynamicImage from './DynamicImage.vue';
 import {useCredentialCommon} from './credentialCommon.js';
@@ -44,6 +44,16 @@ const {
   issuerName, credentialDescription
 } = useCredentialCommon({
   credential: toRef(props, 'credential')
+});
+
+const name = computed(() => {
+  const name = unref(credentialName);
+  return name || 'No credential name available.';
+});
+
+const description = computed(() => {
+  const description = unref(credentialDescription);
+  return description || 'No description available.';
 });
 </script>
 

--- a/components/CredentialDetail.vue
+++ b/components/CredentialDetail.vue
@@ -21,7 +21,7 @@
 
 <script setup>
 /*!
- * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2018-2023 Digital Bazaar, Inc. All rights reserved.
  */
 import {computed, defineProps, toRef, unref} from 'vue';
 import CredentialField from './CredentialField.vue';


### PR DESCRIPTION
#### _Resolves [521](https://github.com/digitalbazaar/veres-wallet/issues/521) from veres-wallet_

---

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

- UI update.

<br/>

### What is the current behavior? (You can also link to an open issue here)

- If a credential is missing a description then its details are blank.

> Current view
>
> <img width="400" alt="current view" src="https://github.com/digitalbazaar/bedrock-vue-vc/assets/56396286/71e6ab11-a935-4d06-a1e8-3b7b136a27f9">


<br/>

### What is the new behavior?

- A credential without a description will display default text informing the user that the credential description is unavailable.

<br/>

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

- [ ] Yes
- [X] No

<br/>

### How has this been tested?

- This has been tested locally by issuing a credential from vc playground to the veres wallet that is missing a description.

<br/>

### Screenshots:

> Credential without description
> 
> <img width="400" alt="no description" src="https://github.com/digitalbazaar/bedrock-vue-vc/assets/56396286/3bc99a9e-a2d2-48d7-803f-f3a3d083da34">
