### PR TITLE
Resolve OBv3 achievement image in credential image fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # bedrock-vue-vc ChangeLog
 
+## 5.1.0 - 2026-mm-dd
+
+### Added
+- `components/credentialDefinitions.js`: a generic, JSON Pointer-based
+  mechanism for vocabulary-specific credential field fallbacks (`image`,
+  `description`, ...). A definition matches a credential by JSON Pointer
+  value (array-membership when the target is an array, e.g. `/type`) and
+  supplies pointers to resolve for fields the core VCDM leaves
+  vocabulary-defined. Adding fallback support for a new vocabulary is a
+  new entry in `credentialDefinitions`, not new conditional logic in a
+  resolver.
+
+### Fixed
+- Resolve an Open Badges v3 (OBv3) achievement image
+  (`credentialSubject.achievement.image`) as a fallback for
+  `credentialImage` when no top-level credential image is present, so
+  OBv3 `OpenBadgeCredential`s no longer show the generic checkbox
+  placeholder icon. Resolved generically via `credentialDefinitions`
+  rather than hardcoded in `credentialImage` itself.
+
 ## 5.0.0 - 2024-04-01
 
 ### Added

--- a/components/credentialCommon.js
+++ b/components/credentialCommon.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {computed, unref} from 'vue';
+import {resolveCredentialDefinitionField} from './credentialDefinitions.js';
 
 /**
  * Common utilities for credential components.
@@ -26,8 +27,16 @@ export function useCredentialCommon({credential}) {
   });
 
   const credentialImage = computed(() => {
-    const {image = null, issuer} = unref(credential);
-    return image ?? issuer?.image ?? issuer?.logo ?? '';
+    const cred = unref(credential);
+    const {image = null, issuer} = cred;
+    // fall back to a vocabulary-specific image (e.g. OBv3's
+    // `credentialSubject.achievement.image`) when no top-level image is
+    // set; the resolved value may itself be a string URL or an image
+    // object (`.id` holds the URL), per the OBv3 vocabulary
+    const definitionImage = resolveCredentialDefinitionField(
+      {credential: cred, field: 'imagePointer'});
+    const definitionImageUrl = definitionImage?.id ?? definitionImage ?? null;
+    return image ?? definitionImageUrl ?? issuer?.image ?? issuer?.logo ?? '';
   });
 
   const issuerName = computed(() => {

--- a/components/credentialDefinitions.js
+++ b/components/credentialDefinitions.js
@@ -1,0 +1,72 @@
+/*!
+ * Copyright (c) 2026 Digital Bazaar, Inc. All rights reserved.
+ */
+/**
+ * Generic, vocabulary-specific fallbacks for credential fields the core
+ * VCDM does not define a fixed location for (e.g. `image`, `description`).
+ * Each definition matches a credential via a map of JSON Pointer (RFC 6901)
+ * => expected value, and supplies JSON Pointers to resolve for fields it
+ * covers. A pointer whose target value is an array (e.g. `/type`) matches
+ * if the array includes the expected value.
+ *
+ * Matching on `/type` rather than `/@context` avoids breaking on
+ * vocabularies (like Open Badges) that mint a new context URL per minor
+ * version -- `type` values are stable across those.
+ */
+export const credentialDefinitions = [
+  {
+    // Open Badges v3 (OBv3) `OpenBadgeCredential`s.
+    matches: {
+      '/type': 'OpenBadgeCredential'
+    },
+    imagePointer: '/credentialSubject/achievement/image',
+    descriptionPointer: '/credentialSubject/achievement/description'
+  }
+];
+
+/**
+ * Resolves a JSON Pointer (RFC 6901) against a value.
+ *
+ * @param {object} options - The options to use.
+ * @param {*} options.value - The value to resolve the pointer against.
+ * @param {string} [options.pointer] - The JSON Pointer to resolve.
+ *
+ * @returns {*} The resolved value, or `undefined` if the pointer is unset
+ *   or any segment is missing.
+ */
+export function getPointerValue({value, pointer}) {
+  if(!pointer) {
+    return undefined;
+  }
+  const segments = pointer.split('/').slice(1).map(
+    segment => segment.replace(/~1/g, '/').replace(/~0/g, '~'));
+  return segments.reduce((target, segment) => target?.[segment], value);
+}
+
+function _matchesDefinition({credential, matches}) {
+  return Object.entries(matches).every(([pointer, expected]) => {
+    const target = getPointerValue({value: credential, pointer});
+    return Array.isArray(target) ?
+      target.includes(expected) : target === expected;
+  });
+}
+
+/**
+ * Finds the first credential definition matching `credential` and resolves
+ * the JSON Pointer named by `field` (e.g. `imagePointer`,
+ * `descriptionPointer`) against it.
+ *
+ * @param {object} options - The options to use.
+ * @param {object} options.credential - The credential to resolve a
+ *   fallback value for.
+ * @param {string} options.field - The definition field naming the JSON
+ *   Pointer to resolve.
+ *
+ * @returns {*} The resolved value, or `undefined` if no definition
+ *   matches, or the matched definition does not set `field`.
+ */
+export function resolveCredentialDefinitionField({credential, field}) {
+  const definition = credentialDefinitions.find(
+    ({matches}) => _matchesDefinition({credential, matches}));
+  return getPointerValue({value: credential, pointer: definition?.[field]});
+}

--- a/test/web/05-credentialDefinitions.js
+++ b/test/web/05-credentialDefinitions.js
@@ -1,0 +1,57 @@
+/*!
+ * Copyright (c) 2026 Digital Bazaar, Inc. All rights reserved.
+ */
+import {
+  getPointerValue, resolveCredentialDefinitionField
+} from '../../components/credentialDefinitions.js';
+import {openBadgeCredential} from './mock-credentials.js';
+
+describe('credentialDefinitions', () => {
+  describe('getPointerValue', () => {
+    it('should resolve a nested pointer', async () => {
+      getPointerValue({
+        value: openBadgeCredential,
+        pointer: '/credentialSubject/achievement/image/id'
+      }).should.equal(
+        openBadgeCredential.credentialSubject.achievement.image.id);
+    });
+
+    it('should return undefined for a missing segment', async () => {
+      should.not.exist(getPointerValue({
+        value: openBadgeCredential, pointer: '/credentialSubject/nonexistent'
+      }));
+    });
+
+    it('should return undefined when no pointer is given', async () => {
+      should.not.exist(getPointerValue({value: openBadgeCredential}));
+    });
+  });
+
+  describe('resolveCredentialDefinitionField', () => {
+    it('should resolve the OBv3 image pointer for an OpenBadgeCredential',
+      async () => {
+        resolveCredentialDefinitionField({
+          credential: openBadgeCredential, field: 'imagePointer'
+        }).should.deep.equal(
+          openBadgeCredential.credentialSubject.achievement.image);
+      });
+
+    it('should return undefined for a credential matching no definition',
+      async () => {
+        should.not.exist(resolveCredentialDefinitionField({
+          credential: {type: ['VerifiableCredential', 'AlumniCredential']},
+          field: 'imagePointer'
+        }));
+      });
+
+    it('should match on `type` array membership, not exact equality',
+      async () => {
+        const credential = {
+          type: ['VerifiableCredential', 'OpenBadgeCredential'],
+          credentialSubject: {achievement: {image: 'x'}}
+        };
+        resolveCredentialDefinitionField({credential, field: 'imagePointer'})
+          .should.equal('x');
+      });
+  });
+});

--- a/test/web/10-CredentialSwitch.js
+++ b/test/web/10-CredentialSwitch.js
@@ -1,7 +1,10 @@
 /*!
  * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import {alumniCredential, basicCredential} from './mock-credentials.js';
+import {
+  alumniCredential, basicCredential, openBadgeCredential,
+  openBadgeCredentialStringAchievementImage
+} from './mock-credentials.js';
 import {CredentialSwitch, registerComponent} from '@bedrock/vue-vc';
 import AlumniDisplay from '../components/examples/alumniDisplay.vue';
 import {config} from '@bedrock/web';
@@ -51,6 +54,33 @@ describe('CredentialSwitch', () => {
       .trim().should.equal('Test Credential');
     vm.$el.querySelector('.cf-value').textContent
       .trim().should.equal(basicCredential.description);
+    tearDown(app);
+  });
+
+  it('should resolve an OBv3 achievement image when no top-level ' +
+    'image is present', async () => {
+    const {app, vm} = await renderCredential({
+      propsData: {credential: openBadgeCredential}});
+    should.exist(vm);
+    should.exist(vm.$el);
+    const img = vm.$el.querySelector('img');
+    should.exist(img);
+    img.getAttribute('src').should.equal(
+      openBadgeCredential.credentialSubject.achievement.image.id);
+    tearDown(app);
+  });
+
+  it('should resolve an OBv3 achievement image when it is a plain ' +
+    'string URL instead of an image object', async () => {
+    const {app, vm} = await renderCredential({
+      propsData: {credential: openBadgeCredentialStringAchievementImage}});
+    should.exist(vm);
+    should.exist(vm.$el);
+    const img = vm.$el.querySelector('img');
+    should.exist(img);
+    img.getAttribute('src').should.equal(
+      openBadgeCredentialStringAchievementImage
+        .credentialSubject.achievement.image);
     tearDown(app);
   });
 

--- a/test/web/mock-credentials.js
+++ b/test/web/mock-credentials.js
@@ -48,3 +48,51 @@ export const basicCredential = {
   description: 'Test description',
   image: 'http://example.com/some-image.png'
 };
+
+export const openBadgeCredential = {
+  '@context': [
+    'https://www.w3.org/2018/credentials/v1',
+    'https://purl.imsglobal.org/spec/ob/v3p0/context.json'
+  ],
+  id: 'http://example.edu/credentials/obv3-1',
+  type: [
+    'VerifiableCredential',
+    'OpenBadgeCredential'
+  ],
+  issuer: {
+    id: 'did:example:issuer',
+    name: 'Example Badge Issuer'
+  },
+  name: 'Open Badge Credential',
+  description: 'The holder earned this badge.',
+  issuanceDate: '2024-01-01T12:00:00Z',
+  credentialSubject: {
+    id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+    type: ['AchievementSubject'],
+    achievement: {
+      id: 'http://example.edu/achievements/1',
+      type: ['Achievement'],
+      name: 'Example Achievement',
+      image: {
+        id: 'http://example.com/achievement-image.png',
+        type: 'Image'
+      }
+    }
+  }
+};
+
+export const openBadgeCredentialStringAchievementImage = {
+  ...openBadgeCredential,
+  id: 'http://example.edu/credentials/obv3-4',
+  name: 'Open Badge Credential (string achievement image)',
+  credentialSubject: {
+    ...openBadgeCredential.credentialSubject,
+    achievement: {
+      ...openBadgeCredential.credentialSubject.achievement,
+      id: 'http://example.edu/achievements/4',
+      // OBv3's achievement `image` may be a plain string URL instead of
+      // an image object with an `id`
+      image: 'http://example.com/string-achievement-image.png'
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- `credentialImage`'s resolver only checked a credential's top-level `image` and the issuer's image/logo, so Open Badges v3 credentials (image nested at `credentialSubject.achievement.image`) fell through to the generic checkbox placeholder on every OBv3-consuming UI (e.g. the "Would you like to store these credentials?" screen).
- Adds a fallback to `credentialSubject.achievement.image` (extracting `.id`) before the issuer image/logo fallback, only when no top-level `image` is present — fixes it once for every consumer instead of per call site.

## Test plan
- [x] New `openBadgeCredential` mock + `CredentialSwitch` test case
- [x] Confirmed test fails without the fix, passes with it (`cd test && npm test`, Karma + headless Chrome)
- [x] Lint clean
- [x] Manually verified live in veres-wallet against two different OBv3 credentials (one missing the top-level `image` entirely)

Addresses #729.