### PR TITLE
Resolve OBv3 achievement description in credential description fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@
   OBv3 `OpenBadgeCredential`s no longer show the generic checkbox
   placeholder icon. Resolved generically via `credentialDefinitions`
   rather than hardcoded in `credentialImage` itself.
+- Resolve an Open Badges v3 (OBv3) achievement description
+  (`credentialSubject.achievement.description`) as a fallback for
+  `credentialDescription` when no top-level credential description is
+  present, so OBv3 `OpenBadgeCredential`s no longer show "No description
+  available." when a real description exists on the achievement.
+  Resolved generically via `credentialDefinitions`, same as the image
+  fallback above.
 
 ## 5.0.0 - 2024-04-01
 

--- a/components/credentialCommon.js
+++ b/components/credentialCommon.js
@@ -45,8 +45,15 @@ export function useCredentialCommon({credential}) {
   });
 
   const credentialDescription = computed(() => {
-    const {description = ''} = unref(credential);
-    return description;
+    const cred = unref(credential);
+    const {description = ''} = cred;
+    // fall back to a vocabulary-specific description (e.g. OBv3's
+    // `credentialSubject.achievement.description`) when no top-level
+    // description is set. Use `||`, not `??`, so an explicit empty string
+    // (not just a missing/undefined field) also triggers the fallback.
+    const definitionDescription = resolveCredentialDefinitionField(
+      {credential: cred, field: 'descriptionPointer'});
+    return description || definitionDescription || '';
   });
 
   return {

--- a/test/web/05-credentialDefinitions.js
+++ b/test/web/05-credentialDefinitions.js
@@ -4,7 +4,9 @@
 import {
   getPointerValue, resolveCredentialDefinitionField
 } from '../../components/credentialDefinitions.js';
-import {openBadgeCredential} from './mock-credentials.js';
+import {
+  openBadgeCredential, openBadgeCredentialNoTopLevelDescription
+} from './mock-credentials.js';
 
 describe('credentialDefinitions', () => {
   describe('getPointerValue', () => {
@@ -35,6 +37,16 @@ describe('credentialDefinitions', () => {
         }).should.deep.equal(
           openBadgeCredential.credentialSubject.achievement.image);
       });
+
+    it('should resolve the OBv3 description pointer for an ' +
+      'OpenBadgeCredential', async () => {
+      resolveCredentialDefinitionField({
+        credential: openBadgeCredentialNoTopLevelDescription,
+        field: 'descriptionPointer'
+      }).should.equal(
+        openBadgeCredentialNoTopLevelDescription
+          .credentialSubject.achievement.description);
+    });
 
     it('should return undefined for a credential matching no definition',
       async () => {

--- a/test/web/10-CredentialSwitch.js
+++ b/test/web/10-CredentialSwitch.js
@@ -3,6 +3,8 @@
  */
 import {
   alumniCredential, basicCredential, openBadgeCredential,
+  openBadgeCredentialEmptyTopLevelDescription,
+  openBadgeCredentialNoTopLevelDescription,
   openBadgeCredentialStringAchievementImage
 } from './mock-credentials.js';
 import {CredentialSwitch, registerComponent} from '@bedrock/vue-vc';
@@ -81,6 +83,30 @@ describe('CredentialSwitch', () => {
     img.getAttribute('src').should.equal(
       openBadgeCredentialStringAchievementImage
         .credentialSubject.achievement.image);
+    tearDown(app);
+  });
+
+  it('should resolve an OBv3 achievement description when no top-level ' +
+    'description is present', async () => {
+    const {app, vm} = await renderCredential({
+      propsData: {credential: openBadgeCredentialNoTopLevelDescription}});
+    should.exist(vm);
+    should.exist(vm.$el);
+    vm.$el.querySelector('.cf-value').textContent.trim().should.equal(
+      openBadgeCredentialNoTopLevelDescription
+        .credentialSubject.achievement.description);
+    tearDown(app);
+  });
+
+  it('should resolve an OBv3 achievement description when the ' +
+    'top-level description is an explicit empty string', async () => {
+    const {app, vm} = await renderCredential({
+      propsData: {credential: openBadgeCredentialEmptyTopLevelDescription}});
+    should.exist(vm);
+    should.exist(vm.$el);
+    vm.$el.querySelector('.cf-value').textContent.trim().should.equal(
+      openBadgeCredentialEmptyTopLevelDescription
+        .credentialSubject.achievement.description);
     tearDown(app);
   });
 

--- a/test/web/mock-credentials.js
+++ b/test/web/mock-credentials.js
@@ -96,3 +96,50 @@ export const openBadgeCredentialStringAchievementImage = {
     }
   }
 };
+
+export const openBadgeCredentialNoTopLevelDescription = {
+  '@context': [
+    'https://www.w3.org/2018/credentials/v1',
+    'https://purl.imsglobal.org/spec/ob/v3p0/context.json'
+  ],
+  id: 'http://example.edu/credentials/obv3-2',
+  type: [
+    'VerifiableCredential',
+    'OpenBadgeCredential'
+  ],
+  issuer: {
+    id: 'did:example:issuer',
+    name: 'Example Badge Issuer'
+  },
+  name: 'Open Badge Credential (no top-level description)',
+  issuanceDate: '2024-01-01T12:00:00Z',
+  credentialSubject: {
+    id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+    type: ['AchievementSubject'],
+    achievement: {
+      id: 'http://example.edu/achievements/2',
+      type: ['Achievement'],
+      name: 'Example Achievement',
+      description: 'The holder earned this achievement.',
+      image: {
+        id: 'http://example.com/achievement-image.png',
+        type: 'Image'
+      }
+    }
+  }
+};
+
+export const openBadgeCredentialEmptyTopLevelDescription = {
+  ...openBadgeCredentialNoTopLevelDescription,
+  id: 'http://example.edu/credentials/obv3-3',
+  name: 'Open Badge Credential (empty top-level description)',
+  description: '',
+  credentialSubject: {
+    ...openBadgeCredentialNoTopLevelDescription.credentialSubject,
+    achievement: {
+      ...openBadgeCredentialNoTopLevelDescription.credentialSubject
+        .achievement,
+      id: 'http://example.edu/achievements/3'
+    }
+  }
+};


### PR DESCRIPTION
## Stacked PR
This is stacked on #12 (DB-729) — the diff shown here is only this branch's own commit. Merge/review #12 first.

## Summary
- Same class of bug as #12, different field: `credentialDescription` only checked the credential's top-level `description`, so OBv3 credentials with a real `achievement.description` but no top-level field showed "No description available."
- Adds a fallback to `credentialSubject.achievement.description`, only when no top-level `description` is present.
- Uses `||`, not `??`, so an explicit empty-string top-level description also triggers the fallback (caught by Codex review — the initial `??` version left that case unfixed).

## Test plan
- [x] New `openBadgeCredentialNoTopLevelDescription` and `openBadgeCredentialEmptyTopLevelDescription` mocks + two `CredentialSwitch` test cases
- [x] Confirmed each new test fails without its corresponding fix and passes with it (`cd test && npm test`, Karma + headless Chrome)
- [x] Lint clean
- [x] Codex-reviewed, no issues found
- [x] Manually verified live in veres-wallet

Addresses #733.