### PR TITLE
Clamp credential title/description to 2 lines instead of 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
   available." when a real description exists on the achievement.
   Resolved generically via `credentialDefinitions`, same as the image
   fallback above.
+- Clamp `CredentialBase.vue`'s title/description to 2 lines instead of
+  hard-truncating to 1 line with an ellipsis, so more of a credential's
+  description is visible in compact/list views before it needs to
+  wrap or clip.
 
 ## 5.0.0 - 2024-04-01
 

--- a/components/CredentialBase.vue
+++ b/components/CredentialBase.vue
@@ -20,7 +20,8 @@
             descriptionOverride : description"
           :value-class="`text-right
             ${textColor ? '':' text-grey-7'}
-            ${dense ? ' text-caption':' text-caption'}`" />
+            ${dense ? ' text-caption':' text-caption'}`"
+          lines="2" />
       </slot>
     </div>
     <q-dialog v-model="state.details">

--- a/test/web/10-CredentialSwitch.js
+++ b/test/web/10-CredentialSwitch.js
@@ -59,6 +59,18 @@ describe('CredentialSwitch', () => {
     tearDown(app);
   });
 
+  it('should clamp the description to 2 lines instead of ' +
+    'truncating to 1', async () => {
+    const {app, vm} = await renderCredential({
+      propsData: {credential: basicCredential}});
+    should.exist(vm);
+    const value = vm.$el.querySelector('.cf-value');
+    should.exist(value);
+    value.classList.contains('ellipsis').should.equal(false);
+    value.style.webkitLineClamp.should.equal('2');
+    tearDown(app);
+  });
+
   it('should resolve an OBv3 achievement image when no top-level ' +
     'image is present', async () => {
     const {app, vm} = await renderCredential({


### PR DESCRIPTION
## Stacked PR
This is stacked on #13 (DB-733), which is itself stacked on #12 (DB-729). The diff shown here is only this branch's own commit. Merge/review in order: #12 -> #13 -> this one.

## Summary
- `CredentialBase.vue`'s `<credential-field>` for title+description never passed a `lines` prop, so Quasar's default (`lines="1"`) hard-truncated the description to a single line with an ellipsis, even when a bit more text would have fit on a second line.
- Passes `lines="2"` instead, switching Quasar to `-webkit-line-clamp: 2`. This doesn't force extra height for text that already fits on one line — only longer text wraps once before clipping.
- Real credential descriptions in flight (ambulance-driver-certificate, verified-email) are still long enough to exceed even a 2-line budget at this box's current width/font-size — shortening that content is a separate, non-code follow-up (see DB-734's Linear description).

## Test plan
- [x] New `CredentialSwitch` test asserting the description box gets the `-webkit-line-clamp: 2` style instead of the `ellipsis` class
- [x] Confirmed the new test fails without the fix and passes with it (`cd test && npm test`, Karma + headless Chrome)
- [x] Lint clean
- [x] Codex-reviewed, no issues found
- [x] Manually verified live in veres-wallet

Addresses #734.