### PR TITLE
Add a maxWidth prop to CredentialField instead of a hardcoded 225px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   vocabulary-defined. Adding fallback support for a new vocabulary is a
   new entry in `credentialDefinitions`, not new conditional logic in a
   resolver.
+- Add `maxWidth` prop to `CredentialField` and `CredentialBase`.
 
 ### Fixed
 - Resolve an Open Badges v3 (OBv3) achievement image

--- a/components/CredentialBase.vue
+++ b/components/CredentialBase.vue
@@ -97,11 +97,6 @@ const props = defineProps({
     type: String,
     default: ''
   },
-  // Forwarded to CredentialField's own maxWidth prop — default matches
-  // CredentialField's default, so callers that don't pass this see no
-  // change. Callers using a wider card than the original ~275px one this
-  // was tuned for can now pass a real value instead of needing a scoped
-  // `!important` CSS override to make their own text fit.
   maxWidth: {
     type: String,
     default: '225px'

--- a/components/CredentialBase.vue
+++ b/components/CredentialBase.vue
@@ -21,6 +21,7 @@
           :value-class="`text-right
             ${textColor ? '':' text-grey-7'}
             ${dense ? ' text-caption':' text-caption'}`"
+          :max-width="maxWidth"
           lines="2" />
       </slot>
     </div>
@@ -95,6 +96,15 @@ const props = defineProps({
   descriptionOverride: {
     type: String,
     default: ''
+  },
+  // Forwarded to CredentialField's own maxWidth prop — default matches
+  // CredentialField's default, so callers that don't pass this see no
+  // change. Callers using a wider card than the original ~275px one this
+  // was tuned for can now pass a real value instead of needing a scoped
+  // `!important` CSS override to make their own text fit.
+  maxWidth: {
+    type: String,
+    default: '225px'
   }
 });
 

--- a/components/CredentialField.vue
+++ b/components/CredentialField.vue
@@ -49,10 +49,6 @@ const props = defineProps({
     type: String,
     default: '1'
   },
-  // Kept as a prop (default matches the original hardcoded value) rather
-  // than a fixed inline style so callers with a wider card don't need to
-  // fight this with a scoped `!important` CSS override to get their own
-  // text to actually fit.
   maxWidth: {
     type: String,
     default: '225px'

--- a/components/CredentialField.vue
+++ b/components/CredentialField.vue
@@ -4,7 +4,7 @@
       <q-item-section>
         <q-item-label
           class="cf-value"
-          style="max-width: 225px;"
+          :style="{maxWidth: maxWidth}"
           :class="valueClass"
           :lines="lines">
           {{value}}
@@ -12,7 +12,7 @@
         <q-item-label
           v-if="title"
           class="cf-title"
-          style="max-width: 225px;"
+          :style="{maxWidth: maxWidth}"
           :class="titleClass"
           :lines="lines">
           {{title}}
@@ -48,6 +48,14 @@ const props = defineProps({
   lines: {
     type: String,
     default: '1'
+  },
+  // Kept as a prop (default matches the original hardcoded value) rather
+  // than a fixed inline style so callers with a wider card don't need to
+  // fight this with a scoped `!important` CSS override to get their own
+  // text to actually fit.
+  maxWidth: {
+    type: String,
+    default: '225px'
   }
 });
 


### PR DESCRIPTION
## Summary
- `CredentialField.vue` hardcoded `max-width: 225px` via inline style, tuned for one specific ~275px-wide card in `bedrock-vue-wallet`'s credential detail dialog.
- That dialog's card has since gotten wider, and rather than generalizing this shared component, the consuming repo added a scoped `!important` CSS override in `CredentialDetails.vue`'s `.card-banner` to fight the hardcoded value locally.
- That works for one caller but doesn't scale — the next consumer needing a different width hits the same wall.
- `maxWidth` is now a real prop on both `CredentialField.vue` and `CredentialBase.vue` (threaded through), default `225px` so existing callers are unaffected.

## Downstream follow-up (not in this PR)
Once this merges and releases, `bedrock-vue-wallet` should bump its `@bedrock/vue-vc` dependency, then replace the `:deep(.cf-value)`/`:deep(.cf-title)` override in `CredentialDetails.vue`'s `.card-banner` with passing `max-width="none"` directly on the two `<credential-switch>` elements, and delete the now-unnecessary CSS override + its comment. See PR #137 in bedrock-vue-wallet, which currently carries that override as a documented temporary stopgap pending this.

## Test plan
- [ ] Existing callers with no `maxWidth` passed render identically (default `225px` unchanged).
- [ ] A caller passing a custom `maxWidth` (e.g. `none`) renders the field/title without truncation at that width.