### PR TITLE
Require @bedrock/quasar v11 in the peer dependency range.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # bedrock-vue-vc ChangeLog
 
+## 6.0.0 - 2026-09-dd
+
+### Changed
+- **BREAKING**: Require `@bedrock/quasar@11`, replacing `@bedrock/quasar@10`,
+  in the peer dependency range. That release moves to `@bedrock/vue@6`; this
+  package does not use `@bedrock/vue` itself, so no code changes are needed
+  here. The existing `vue@^3.5.42` range already satisfies what
+  `@bedrock/quasar@11` requires.
+
 ## 5.1.0 - 2026-09-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-vue-vc",
   "peerDependencies": {
-    "@bedrock/quasar": "^10.0.1",
+    "@bedrock/quasar": "^11.0.0",
     "@bedrock/web": "^3.1.0",
     "vue": "^3.5.42"
   },


### PR DESCRIPTION
Requires `@bedrock/quasar@11` instead of v10, so this releases as 6.0.0. No code changes needed, since this package doesn't use `@bedrock/vue` itself and only picks it up through `@bedrock/quasar`, and the existing `vue@^3.5.42` range already satisfies what v11 requires.

Draft until `@bedrock/quasar@11.0.0` publishes. Until then CI fails at install with `ETARGET: No matching version found for @bedrock/quasar@^11.0.0`.
